### PR TITLE
[FEATURE] Populate Projects with TodoItems

### DIFF
--- a/src/dummy-data/projects.js
+++ b/src/dummy-data/projects.js
@@ -3,7 +3,6 @@ import todoItemsAttributes from './todoItems';
 const projectsAttributes = [
 	{
 		name: 'Default',
-		todoItems: todoItemsAttributes.slice(0, -1)
 	},
 	{
 		name: 'Data Structures Final Project',

--- a/src/factories/project.js
+++ b/src/factories/project.js
@@ -1,7 +1,16 @@
 const Project = ({ name, todoItems=[] }) => {
+	const populateWithBelongingTodoItems = function(todoItems) {
+		this.todoItems = todoItems.filter((todoItem) => {
+			return todoItem.belongsToProjectName(this.name);
+		});
+
+		console.log(this.todoItems);
+	};
+
 	return {
 		name,
-		todoItems
+		todoItems,
+		populateWithBelongingTodoItems,
 	};
 };
 

--- a/src/factories/todoItem.js
+++ b/src/factories/todoItem.js
@@ -1,9 +1,17 @@
-const TodoItem = ({ title, description, dueDate, priority}) => {
+const DefaultProjectName = "Default";
+
+const TodoItem = ({ title, description, dueDate, priority, projectName=DefaultProjectName }) => {
+	const belongsToProjectName = function(projectName) {
+		return this.projectName === projectName;
+	};
+
 	return {
+		projectName,
 		title,
 		description,
 		dueDate,
-		priority
+		priority,
+		belongsToProjectName,
 	};
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import todoItemsAttributes from './dummy-data/todoItems';
 import TodoItem from './factories/todoItem';
+import projectsAttributes from './dummy-data/projects';
+import Project from './factories/project';
 
 function component() {
   const element = document.createElement('div');
@@ -12,5 +14,12 @@ function component() {
 document.body.appendChild(component());
 
 const todoItems = todoItemsAttributes.map( (attributes) => TodoItem(attributes));
-
 console.dir(todoItems);
+
+const projects = projectsAttributes.map( (attributes) => Project(attributes) );
+console.dir(projects);
+
+projects.forEach((project) => {
+  project.populateWithBelongingTodoItems(todoItems);
+});
+console.dir(projects);


### PR DESCRIPTION
In order to associate a set of TodoItems with a Project, the
ability to bulk load todoItems into a Project must be provided.

Exposing a method that from a given list of TodoItems, picks out
those that belong to a Project and adds them to it.