### PR TITLE
[FIX] Correct references to factories

### DIFF
--- a/src/factories/project.js
+++ b/src/factories/project.js
@@ -12,4 +12,4 @@ const createProject = ({ name, todoItems=[] }) => {
 	};
 };
 
-export default Project;
+export default createProject;

--- a/src/factories/todoItem.js
+++ b/src/factories/todoItem.js
@@ -15,4 +15,4 @@ const createTodoItem = ({ title, description, dueDate, priority, projectName=Def
 	};
 };
 
-export default TodoItem;
+export default createTodoItem;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import todoItemsAttributes from './dummy-data/todoItems';
-import TodoItem from './factories/todoItem';
+import createTodoItem from './factories/todoItem';
 import projectsAttributes from './dummy-data/projects';
-import Project from './factories/project';
+import createProject from './factories/project';
 
 function component() {
   const element = document.createElement('div');


### PR DESCRIPTION
After changing the factory function names from `Object` to
`create+Object`, there were some dangling references that were
not updated.